### PR TITLE
[H3] Fix for TreasureStakingRules

### DIFF
--- a/contracts/harvester/rules/TreasureStakingRules.sol
+++ b/contracts/harvester/rules/TreasureStakingRules.sol
@@ -35,7 +35,8 @@ contract TreasureStakingRules is StakingRulesBase {
     /// @inheritdoc IStakingRules
     function getHarvesterBoost() external pure returns (uint256) {
         // Treasure staking only boosts userBoost, not harvesterBoost
-        return 0;
+        // return 0;
+        return Constant.ONE;
     }
 
     function getTreasureBoost(uint256 _tokenId, uint256 _amount) public pure returns (uint256 boost) {

--- a/contracts/harvester/rules/TreasureStakingRules.sol
+++ b/contracts/harvester/rules/TreasureStakingRules.sol
@@ -35,7 +35,6 @@ contract TreasureStakingRules is StakingRulesBase {
     /// @inheritdoc IStakingRules
     function getHarvesterBoost() external pure returns (uint256) {
         // Treasure staking only boosts userBoost, not harvesterBoost
-        // return 0;
         return Constant.ONE;
     }
 

--- a/foundry/test/harvester/rules/TreasureStakingRules.t.sol
+++ b/foundry/test/harvester/rules/TreasureStakingRules.t.sol
@@ -109,7 +109,7 @@ contract TreasureStakingRulesTest is TestUtils {
         vm.prank(harvesterFactory);
         treasureRules.setNftHandler(address(this));
 
-        vm.assume(_amount > 0 && _amount < 10);
+        vm.assume(_amount > 0 && _amount < 1e6);
 
         vm.prank(admin);
         treasureRules.setMaxStakeablePerUser(_amount);
@@ -120,9 +120,9 @@ contract TreasureStakingRulesTest is TestUtils {
         treasureRules.canStake(_user, _nft, _tokenId, _amount);
         assertEq(treasureRules.getAmountTreasuresStaked(_user), _amount);
 
-        // TreasureStakingRules harvesterBoost is always 0,
+        // TreasureStakingRules harvesterBoost multiplier is always 1 (no effect),
         // no matter how many Treasures are staked, affects userBoost only
-        assertEq(treasureRules.getHarvesterBoost(), 0);
+        assertEq(treasureRules.getHarvesterBoost(), Constant.ONE);
     }
 
     function test_canStake(


### PR DESCRIPTION
I made a bug and am adding a fix for: [H-3] Harvesters with TreasureStakingRules configured cannot receive rewards.

Basically:
![image](https://user-images.githubusercontent.com/4037878/179659529-4531c8f1-24b6-4604-8f44-cacc40a0db1d.png)

Should be this:
![image](https://user-images.githubusercontent.com/4037878/179659593-f3d9386e-c138-4178-9e38-4d7e74cf7701.png)
