### PR TITLE
Fix: [L-3] Particular order of operations leads to deposit positions which cannot be properly cleaned up

### DIFF
--- a/contracts/harvester/CorruptionToken.sol
+++ b/contracts/harvester/CorruptionToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.11;
 
-import '@openzeppelin/contracts/token/presets/ERC20PresetMinterPauser.sol';
+import '@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
 
 contract CorruptionToken is ERC20, Ownable {

--- a/contracts/harvester/Harvester.sol
+++ b/contracts/harvester/Harvester.sol
@@ -325,9 +325,9 @@ contract Harvester is IHarvester, Initializable, AccessControlEnumerableUpgradea
 
         int256 amountInt = _amount.toInt256();
         int256 lockLpAmountInt = lockLpAmount.toInt256();
-        uint256 pendingRewards = _recalculateGlobalLp(msg.sender, -amountInt, -lockLpAmountInt);
+        _recalculateGlobalLp(msg.sender, -amountInt, -lockLpAmountInt);
 
-        if (user.depositAmount == 0 && user.lockLpAmount == 0 && pendingRewards == 0) {
+        if (user.depositAmount == 0 && user.lockLpAmount == 0) {
             _removeDeposit(msg.sender, _depositId);
         }
 


### PR DESCRIPTION
`withdrawPosition` uses modifier `updateRewards` so execution of the function is done on the updated rewards state. `user.depositAmount == 0 && user.lockLpAmount == 0` conditions make sure that the user withdrew the whole deposit from the position and lp tokens have been zero'd out as well. By calling `_recalculateGlobalLp(msg.sender, -amountInt, -lockLpAmountInt)` we make sure that global lp tokens are adjusted properly. 

It does not matter if pending rewards are present or not because lp tokens for this given deposit have been subtracted already and this deposit will not earn any additional rewards. That means it can be removed even if pending rewards are present.

Pending rewards check was a leftover from the previous implementation where rewards were calculated per deposit and removing a deposit was equivalent to losing unclaimed rewards which is not the case anymore.