### PR TITLE
Fix: [Q-9] Rename canStake and canUnstake in IStakingRules

### DIFF
--- a/contracts/harvester/NftHandler.sol
+++ b/contracts/harvester/NftHandler.sol
@@ -61,21 +61,21 @@ contract NftHandler is INftHandler, AccessControlEnumerableUpgradeable, ERC721Ho
         _;
     }
 
-    modifier canStake(address _user, address _nft, uint256 _tokenId, uint256 _amount) {
+    modifier processStake(address _user, address _nft, uint256 _tokenId, uint256 _amount) {
         IStakingRules stakingRules = getStakingRules(_nft, _tokenId);
 
         if (address(stakingRules) == address(0)) revert("NoStakingRules()");
 
-        stakingRules.canStake(msg.sender, _nft, _tokenId, _amount);
+        stakingRules.processStake(msg.sender, _nft, _tokenId, _amount);
 
         _;
     }
 
-    modifier canUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount) {
+    modifier processUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount) {
         IStakingRules stakingRules = getStakingRules(_nft, _tokenId);
 
         if (address(stakingRules) != address(0)) {
-            stakingRules.canUnstake(msg.sender, _nft, _tokenId, _amount);
+            stakingRules.processUnstake(msg.sender, _nft, _tokenId, _amount);
         }
 
         _;
@@ -171,7 +171,7 @@ contract NftHandler is INftHandler, AccessControlEnumerableUpgradeable, ERC721Ho
     function stakeNft(address _nft, uint256 _tokenId, uint256 _amount)
         public
         validateInput(_nft, _amount)
-        canStake(msg.sender, _nft, _tokenId, _amount)
+        processStake(msg.sender, _nft, _tokenId, _amount)
     {
         Interfaces supportedInterface = getSupportedInterface(_nft, _tokenId);
 
@@ -207,7 +207,7 @@ contract NftHandler is INftHandler, AccessControlEnumerableUpgradeable, ERC721Ho
     function unstakeNft(address _nft, uint256 _tokenId, uint256 _amount)
         public
         validateInput(_nft, _amount)
-        canUnstake(msg.sender, _nft, _tokenId, _amount)
+        processUnstake(msg.sender, _nft, _tokenId, _amount)
     {
         Interfaces supportedInterface = getSupportedInterface(_nft, _tokenId);
 

--- a/contracts/harvester/interfaces/IStakingRules.sol
+++ b/contracts/harvester/interfaces/IStakingRules.sol
@@ -7,14 +7,14 @@ interface IStakingRules {
     /// @param _nft NFT address, can be either ERC721 or ERC1155
     /// @param _tokenId token Id of staked NFT
     /// @param _amount number of NFTs staked, must be 1 for ERC721
-    function canStake(address _user, address _nft, uint256 _tokenId, uint256 _amount) external;
+    function processStake(address _user, address _nft, uint256 _tokenId, uint256 _amount) external;
 
     /// @notice Checks if NFT can be unstaked
     /// @param _user wallet that is unstaking the NFT
     /// @param _nft NFT address, can be either ERC721 or ERC1155
     /// @param _tokenId token Id of unstaked NFT
     /// @param _amount number of NFTs unstaked, must be 1 for ERC721
-    function canUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount) external;
+    function processUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount) external;
 
     /// @notice Gets amount of boost that user gets by staking given NFT
     /// @param _user wallet for which to calculate boost

--- a/contracts/harvester/rules/ExtractorStakingRules.sol
+++ b/contracts/harvester/rules/ExtractorStakingRules.sol
@@ -121,7 +121,7 @@ contract ExtractorStakingRules is IExtractorStakingRules, StakingRulesBase {
         emit ExtractorReplaced(_tokenId, _replacedSpotId);
     }
 
-    function _canStake(address _user, address _nft, uint256 _tokenId, uint256 _amount)
+    function _processStake(address _user, address _nft, uint256 _tokenId, uint256 _amount)
         internal
         override
         validateInput(_nft, _amount)
@@ -141,7 +141,7 @@ contract ExtractorStakingRules is IExtractorStakingRules, StakingRulesBase {
         emit ExtractorStaked(_tokenId, spotId, _amount);
     }
 
-    function _canUnstake(address, address, uint256, uint256) internal pure override {
+    function _processUnstake(address, address, uint256, uint256) internal pure override {
         revert("CannotUnstake()");
     }
 

--- a/contracts/harvester/rules/LegionStakingRules.sol
+++ b/contracts/harvester/rules/LegionStakingRules.sol
@@ -154,7 +154,7 @@ contract LegionStakingRules is StakingRulesBase {
         return 0;
     }
 
-    function _canStake(address _user, address, uint256 _tokenId, uint256) internal override {
+    function _processStake(address _user, address, uint256 _tokenId, uint256) internal override {
         staked++;
         totalRank += getRank(_tokenId);
         weightStaked[_user] += getWeight(_tokenId);
@@ -162,7 +162,7 @@ contract LegionStakingRules is StakingRulesBase {
         if (weightStaked[_user] > maxLegionWeight) revert("MaxWeight()");
     }
 
-    function _canUnstake(address _user, address, uint256 _tokenId, uint256) internal override {
+    function _processUnstake(address _user, address, uint256 _tokenId, uint256) internal override {
         staked--;
         totalRank -= getRank(_tokenId);
         weightStaked[_user] -= getWeight(_tokenId);

--- a/contracts/harvester/rules/PartsStakingRules.sol
+++ b/contracts/harvester/rules/PartsStakingRules.sol
@@ -62,7 +62,7 @@ contract PartsStakingRules is StakingRulesBase {
         return Constant.ONE + (2 * n - n ** 2 / maxParts) * boost / maxParts;
     }
 
-    function _canStake(address _user, address, uint256, uint256 _amount)
+    function _processStake(address _user, address, uint256, uint256 _amount)
         internal
         override
         validateInput(_user, _amount)
@@ -76,7 +76,7 @@ contract PartsStakingRules is StakingRulesBase {
         getAmountStaked[_user] = amountStakedCache + _amount;
     }
 
-    function _canUnstake(address _user, address, uint256, uint256 _amount)
+    function _processUnstake(address _user, address, uint256, uint256 _amount)
         internal
         override
         validateInput(_user, _amount)

--- a/contracts/harvester/rules/StakingRulesBase.sol
+++ b/contracts/harvester/rules/StakingRulesBase.sol
@@ -33,21 +33,21 @@ abstract contract StakingRulesBase is IStakingRules, AccessControlEnumerableUpgr
     }
 
     /// @inheritdoc IStakingRules
-    function canStake(address _user, address _nft, uint256 _tokenId, uint256 _amount)
+    function processStake(address _user, address _nft, uint256 _tokenId, uint256 _amount)
         external
         override
         onlyRole(SR_NFT_HANDLER)
     {
-        _canStake(_user, _nft, _tokenId, _amount);
+        _processStake(_user, _nft, _tokenId, _amount);
     }
 
     /// @inheritdoc IStakingRules
-    function canUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount)
+    function processUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount)
         external
         override
         onlyRole(SR_NFT_HANDLER)
     {
-        _canUnstake(_user, _nft, _tokenId, _amount);
+        _processUnstake(_user, _nft, _tokenId, _amount);
     }
 
     /// @inheritdoc IStakingRules
@@ -59,8 +59,8 @@ abstract contract StakingRulesBase is IStakingRules, AccessControlEnumerableUpgr
     }
 
     /// @dev it's meant to be overriden by staking rules implementation
-    function _canStake(address, address, uint256, uint256) internal virtual {}
+    function _processStake(address, address, uint256, uint256) internal virtual {}
 
     /// @dev it's meant to be overriden by staking rules implementation
-    function _canUnstake(address, address, uint256, uint256) internal virtual {}
+    function _processUnstake(address, address, uint256, uint256) internal virtual {}
 }

--- a/contracts/harvester/rules/TreasureStakingRules.sol
+++ b/contracts/harvester/rules/TreasureStakingRules.sol
@@ -134,7 +134,7 @@ contract TreasureStakingRules is StakingRulesBase {
         boost = boost * _amount;
     }
 
-    function _canStake(address _user, address, uint256, uint256 _amount)
+    function _processStake(address _user, address, uint256, uint256 _amount)
         internal
         override
         validateInput(_user, _amount)
@@ -145,7 +145,7 @@ contract TreasureStakingRules is StakingRulesBase {
         getAmountTreasuresStaked[_user] = amountStakedCache + _amount;
     }
 
-    function _canUnstake(address _user, address, uint256, uint256 _amount)
+    function _processUnstake(address _user, address, uint256, uint256 _amount)
         internal
         override
         validateInput(_user, _amount)

--- a/foundry/test/harvester/NftHandler.t.sol
+++ b/foundry/test/harvester/NftHandler.t.sol
@@ -789,7 +789,7 @@ contract NftHandlerTest is TestUtils, ERC721Holder, ERC1155Holder {
 
         vm.mockCall(
             address(erc1155StakingRules),
-            abi.encodeCall(IStakingRules.canUnstake, (address(this), address(nftErc1155), tokenId, amount + 1)),
+            abi.encodeCall(IStakingRules.processUnstake, (address(this), address(nftErc1155), tokenId, amount + 1)),
             abi.encode(bytes(""))
         );
         nftErc1155.mint(address(nftHandler), tokenId, 1);
@@ -818,7 +818,7 @@ contract NftHandlerTest is TestUtils, ERC721Holder, ERC1155Holder {
 
         vm.mockCall(
             address(erc1155StakingRules),
-            abi.encodeCall(IStakingRules.canUnstake, (address(this), address(nftErc1155), tokenId, amount + 1)),
+            abi.encodeCall(IStakingRules.processUnstake, (address(this), address(nftErc1155), tokenId, amount + 1)),
             abi.encode(bytes(""))
         );
         nftErc1155.mint(address(nftHandler), tokenId, 1);

--- a/foundry/test/harvester/rules/ExtractorStakingRules.t.sol
+++ b/foundry/test/harvester/rules/ExtractorStakingRules.t.sol
@@ -51,10 +51,10 @@ contract ExtractorStakingRulesTest is TestUtils {
         vm.prank(admin);
         extractorRules.setExtractorBoost(_tokenId, extractorBoost);
 
-        extractorRules.canStake(_user, extractorAddress, _tokenId, _amount);
+        extractorRules.processStake(_user, extractorAddress, _tokenId, _amount);
     }
 
-    function test_canStake(
+    function test_processStake(
         address _user,
         uint256 _tokenId,
         uint256 _amount
@@ -63,25 +63,25 @@ contract ExtractorStakingRulesTest is TestUtils {
 
         bytes memory errorMsg = TestUtils.getAccessControlErrorMsg(address(this), extractorRules.SR_NFT_HANDLER());
         vm.expectRevert(errorMsg);
-        extractorRules.canStake(_user, extractorAddress, _tokenId, _amount);
+        extractorRules.processStake(_user, extractorAddress, _tokenId, _amount);
 
         vm.prank(harvesterFactory);
         extractorRules.setNftHandler(address(this));
 
         vm.expectRevert("InvalidAddress()");
-        extractorRules.canStake(_user, address(999), _tokenId, _amount);
+        extractorRules.processStake(_user, address(999), _tokenId, _amount);
 
         vm.expectRevert("ZeroAmount()");
-        extractorRules.canStake(_user, extractorAddress, _tokenId, 0);
+        extractorRules.processStake(_user, extractorAddress, _tokenId, 0);
 
         vm.expectRevert(bytes("ZeroBoost()"));
-        extractorRules.canStake(_user, extractorAddress, _tokenId, _amount);
+        extractorRules.processStake(_user, extractorAddress, _tokenId, _amount);
 
         vm.prank(admin);
         extractorRules.setExtractorBoost(_tokenId, extractorBoost);
 
         vm.expectRevert(bytes("MaxStakeable()"));
-        extractorRules.canStake(_user, extractorAddress, _tokenId, maxStakeable + 1);
+        extractorRules.processStake(_user, extractorAddress, _tokenId, maxStakeable + 1);
 
         assertEq(extractorRules.getExtractorCount(), 0);
 
@@ -89,7 +89,7 @@ contract ExtractorStakingRulesTest is TestUtils {
 
         vm.expectEmit(true, true, true, true);
         emit ExtractorStaked(_tokenId, spotId, _amount);
-        extractorRules.canStake(_user, extractorAddress, _tokenId, _amount);
+        extractorRules.processStake(_user, extractorAddress, _tokenId, _amount);
 
         assertEq(extractorRules.getExtractorCount(), _amount);
 
@@ -110,16 +110,16 @@ contract ExtractorStakingRulesTest is TestUtils {
         assertEq(extractorRules.getUserBoost(_user, extractorAddress, _tokenId, _amount), 0);
     }
 
-    function test_canUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount) public {
+    function test_processUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount) public {
         bytes memory errorMsg = TestUtils.getAccessControlErrorMsg(address(this), extractorRules.SR_NFT_HANDLER());
         vm.expectRevert(errorMsg);
-        extractorRules.canUnstake(_user, _nft, _tokenId, _amount);
+        extractorRules.processUnstake(_user, _nft, _tokenId, _amount);
 
         vm.prank(harvesterFactory);
         extractorRules.setNftHandler(address(this));
 
         vm.expectRevert("CannotUnstake()");
-        extractorRules.canUnstake(_user, _nft, _tokenId, _amount);
+        extractorRules.processUnstake(_user, _nft, _tokenId, _amount);
     }
 
     struct LocalVars {
@@ -221,7 +221,7 @@ contract ExtractorStakingRulesTest is TestUtils {
         assertEq(extractorRules.getExtractorCount(), maxStakeable);
 
         vm.expectRevert(bytes("MaxStakeable()"));
-        extractorRules.canStake(user, extractorAddress, tokenId, 1);
+        extractorRules.processStake(user, extractorAddress, tokenId, 1);
 
         assertEq(extractorRules.getExtractorCount(), maxStakeable);
     }

--- a/foundry/test/harvester/rules/LegionStakingRules.t.sol
+++ b/foundry/test/harvester/rules/LegionStakingRules.t.sol
@@ -208,8 +208,8 @@ contract LegionStakingRulesTest is TestUtils {
         }
     }
 
-    // function test_canStake() public {}
-    // function test_canUnstake() public {}
+    // function test_processStake() public {}
+    // function test_processUnstake() public {}
 
     function test_setLegionMetadataStore() public {
         assertEq(address(legionRules.legionMetadataStore()), legionMetadataStore);

--- a/foundry/test/harvester/rules/StakingRulesBase.t.sol
+++ b/foundry/test/harvester/rules/StakingRulesBase.t.sol
@@ -14,8 +14,8 @@ contract StakingRulesBaseImpl is StakingRulesBase {
         _initStakingRulesBase(_admin, _harvesterFactory);
     }
     // implement abstract methods so it's deployable
-    function _canStake(address _user, address, uint256, uint256 _amount) internal override {}
-    function _canUnstake(address _user, address, uint256, uint256 _amount) internal override {}
+    function _processStake(address _user, address, uint256, uint256 _amount) internal override {}
+    function _processUnstake(address _user, address, uint256, uint256 _amount) internal override {}
     function getUserBoost(address, address, uint256, uint256) external pure override returns (uint256) {}
     function getHarvesterBoost() external view returns (uint256) {}
 }
@@ -70,25 +70,25 @@ contract StakingRulesBaseTest is TestUtils {
         assertFalse(stakingRules.hasRole(stakingRules.SR_HARVESTER_FACTORY(), harvesterFactory));
     }
 
-    function test_canStake() public {
+    function test_processStake() public {
         bytes memory errorMsg = TestUtils.getAccessControlErrorMsg(address(this), stakingRules.SR_NFT_HANDLER());
         vm.expectRevert(errorMsg);
-        stakingRules.canStake(address(1), address(1), 1, 1);
+        stakingRules.processStake(address(1), address(1), 1, 1);
 
         vm.prank(harvesterFactory);
         stakingRules.setNftHandler(address(this));
 
-        stakingRules.canStake(address(1), address(1), 1, 1);
+        stakingRules.processStake(address(1), address(1), 1, 1);
     }
 
-    function test_canUnstake() public {
+    function test_processUnstake() public {
         bytes memory errorMsg = TestUtils.getAccessControlErrorMsg(address(this), stakingRules.SR_NFT_HANDLER());
         vm.expectRevert(errorMsg);
-        stakingRules.canUnstake(address(1), address(1), 1, 1);
+        stakingRules.processUnstake(address(1), address(1), 1, 1);
 
         vm.prank(harvesterFactory);
         stakingRules.setNftHandler(address(this));
 
-        stakingRules.canUnstake(address(1), address(1), 1, 1);
+        stakingRules.processUnstake(address(1), address(1), 1, 1);
     }
 }

--- a/foundry/test/harvester/rules/TreasureStakingRules.t.sol
+++ b/foundry/test/harvester/rules/TreasureStakingRules.t.sol
@@ -123,7 +123,7 @@ contract TreasureStakingRulesTest is TestUtils {
 
         vm.assume(_user != address(0));
 
-        treasureRules.canStake(_user, _nft, _tokenId, _amount);
+        treasureRules.processStake(_user, _nft, _tokenId, _amount);
         assertEq(treasureRules.getAmountTreasuresStaked(_user), _amount);
 
         // TreasureStakingRules harvesterBoost multiplier is always 1 (no effect),
@@ -131,7 +131,7 @@ contract TreasureStakingRulesTest is TestUtils {
         assertEq(treasureRules.getHarvesterBoost(), Constant.ONE);
     }
 
-    function test_canStake(
+    function test_processStake(
         address _user,
         address _nft,
         uint256 _tokenId,
@@ -139,18 +139,18 @@ contract TreasureStakingRulesTest is TestUtils {
     ) public {
         bytes memory errorMsg = TestUtils.getAccessControlErrorMsg(address(this), treasureRules.SR_NFT_HANDLER());
         vm.expectRevert(errorMsg);
-        treasureRules.canStake(_user, _nft, _tokenId, _amount);
+        treasureRules.processStake(_user, _nft, _tokenId, _amount);
 
         vm.prank(harvesterFactory);
         treasureRules.setNftHandler(address(this));
 
         vm.expectRevert("ZeroAddress()");
-        treasureRules.canStake(address(0), _nft, _tokenId, _amount);
+        treasureRules.processStake(address(0), _nft, _tokenId, _amount);
 
         vm.assume(_user != address(0));
 
         vm.expectRevert("ZeroAmount()");
-        treasureRules.canStake(_user, _nft, _tokenId, 0);
+        treasureRules.processStake(_user, _nft, _tokenId, 0);
 
         vm.assume(_amount > 0 && _amount < 1e18);
 
@@ -160,32 +160,32 @@ contract TreasureStakingRulesTest is TestUtils {
         assertEq(treasureRules.maxStakeablePerUser(), _amount);
         assertEq(treasureRules.getAmountTreasuresStaked(_user), 0);
 
-        treasureRules.canStake(_user, _nft, _tokenId, _amount);
+        treasureRules.processStake(_user, _nft, _tokenId, _amount);
         assertEq(treasureRules.getAmountTreasuresStaked(_user), _amount);
 
         vm.expectRevert("MaxStakeablePerUser()");
-        treasureRules.canStake(_user, _nft, _tokenId, _amount + 1);
+        treasureRules.processStake(_user, _nft, _tokenId, _amount + 1);
 
         assertEq(treasureRules.getAmountTreasuresStaked(_user), _amount);
     }
 
-    function test_canUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount) public {
+    function test_processUnstake(address _user, address _nft, uint256 _tokenId, uint256 _amount) public {
         bytes memory errorMsg = TestUtils.getAccessControlErrorMsg(address(this), treasureRules.SR_NFT_HANDLER());
         vm.expectRevert(errorMsg);
-        treasureRules.canUnstake(_user, _nft, _tokenId, _amount);
+        treasureRules.processUnstake(_user, _nft, _tokenId, _amount);
 
         vm.prank(harvesterFactory);
         treasureRules.setNftHandler(nftHandler);
 
         vm.prank(nftHandler);
         vm.expectRevert("ZeroAddress()");
-        treasureRules.canUnstake(address(0), _nft, _tokenId, _amount);
+        treasureRules.processUnstake(address(0), _nft, _tokenId, _amount);
 
         vm.assume(_user != address(0));
 
         vm.prank(nftHandler);
         vm.expectRevert("ZeroAmount()");
-        treasureRules.canUnstake(_user, _nft, _tokenId, 0);
+        treasureRules.processUnstake(_user, _nft, _tokenId, 0);
 
         vm.assume(maxStakeablePerUser < _amount);
 
@@ -193,15 +193,15 @@ contract TreasureStakingRulesTest is TestUtils {
         treasureRules.setMaxStakeablePerUser(_amount);
 
         vm.prank(nftHandler);
-        treasureRules.canStake(_user, _nft, _tokenId, _amount);
+        treasureRules.processStake(_user, _nft, _tokenId, _amount);
 
         vm.prank(nftHandler);
-        treasureRules.canUnstake(_user, _nft, _tokenId, _amount - 1);
+        treasureRules.processUnstake(_user, _nft, _tokenId, _amount - 1);
 
         assertEq(treasureRules.getAmountTreasuresStaked(_user), 1);
 
         vm.prank(nftHandler);
-        treasureRules.canUnstake(_user, _nft, _tokenId, 1);
+        treasureRules.processUnstake(_user, _nft, _tokenId, 1);
 
         assertEq(treasureRules.getAmountTreasuresStaked(_user), 0);
     }


### PR DESCRIPTION
Fixes #65 